### PR TITLE
Update trade visualization lines

### DIFF
--- a/BTC_V3_Hybrid.pine
+++ b/BTC_V3_Hybrid.pine
@@ -61,61 +61,40 @@ canLong    = longSignal and maFilter and adxFilter and atrFilter
 // Храним цену первого входа и бар
 var float prvEntryPrice = na
 var int   entryBar      = na
+var bool  tradeActive   = false
 
 // линии отображения сделки
-var line entryLine = na
-var line tpLine    = na
-var line stopLine  = na
+var line entryLine  = na
+var line tpLine     = na
+var line stopLine   = na
 var line layer2Line = na
 var line layer3Line = na
 var line layer4Line = na
-
-if strategy.position_size == 0
-    prvEntryPrice := na
-    entryBar := na
-    // удаляем линии предыдущей сделки
-    if not na(entryLine)
-        line.delete(entryLine)
-        entryLine := na
-    if not na(tpLine)
-        line.delete(tpLine)
-        tpLine := na
-    if not na(stopLine)
-        line.delete(stopLine)
-        stopLine := na
-    if not na(layer2Line)
-        line.delete(layer2Line)
-        layer2Line := na
-    if not na(layer3Line)
-        line.delete(layer3Line)
-        layer3Line := na
-    if not na(layer4Line)
-        line.delete(layer4Line)
-        layer4Line := na
 
 // Первый вход
 if canLong
     strategy.entry("Long1", strategy.long)
 
 // Сохраняем цену первого входа
-if strategy.position_size > 0 and strategy.opentrades == 1 and na(prvEntryPrice)
+if strategy.position_size > 0 and strategy.opentrades == 1 and not tradeActive
     prvEntryPrice := strategy.position_avg_price
     entryBar := bar_index
+    tradeActive := true
     // создаем линии для текущей сделки
     entryLine := line.new(bar_index, prvEntryPrice, bar_index, prvEntryPrice,
-        extend=extend.right, color=color.blue, width=2)
+        color=color.blue, width=2)
     tpPrice = prvEntryPrice * (1 + deferTP / 100)
     tpLine := line.new(bar_index, tpPrice, bar_index, tpPrice,
-        extend=extend.right, color=color.green, width=2)
+        color=color.green, width=2)
     // линии уровней усреднения
     layer2Line := line.new(bar_index, prvEntryPrice * (1 - layer2 / 100),
-        bar_index, prvEntryPrice * (1 - layer2 / 100), extend=extend.right,
+        bar_index, prvEntryPrice * (1 - layer2 / 100),
         color=color.yellow, style=line.style_dotted)
     layer3Line := line.new(bar_index, prvEntryPrice * (1 - layer3 / 100),
-        bar_index, prvEntryPrice * (1 - layer3 / 100), extend=extend.right,
+        bar_index, prvEntryPrice * (1 - layer3 / 100),
         color=color.yellow, style=line.style_dotted)
     layer4Line := line.new(bar_index, prvEntryPrice * (1 - layer4 / 100),
-        bar_index, prvEntryPrice * (1 - layer4 / 100), extend=extend.right,
+        bar_index, prvEntryPrice * (1 - layer4 / 100),
         color=color.yellow, style=line.style_dotted)
 
 // === Пирамидинг (усреднение при падении цены)
@@ -131,11 +110,18 @@ if strategy.position_size > 0 and not na(prvEntryPrice)
 // === Вычисление прибыли позиции
 posProfitPerc = strategy.position_size != 0 ? (close - strategy.position_avg_price) / strategy.position_avg_price * 100 : 0.0
 
-// обновляем линию тейка в соответствии со средней ценой позиции
-if strategy.position_size > 0 and not na(tpLine)
+// обновляем линии во время открытой сделки
+if strategy.position_size > 0 and tradeActive
     curTP = strategy.position_avg_price * (1 + deferTP / 100)
     line.set_y1(tpLine, curTP)
     line.set_y2(tpLine, curTP)
+    line.set_x2(entryLine, bar_index)
+    line.set_x2(tpLine, bar_index)
+    line.set_x2(layer2Line, bar_index)
+    line.set_x2(layer3Line, bar_index)
+    line.set_x2(layer4Line, bar_index)
+    if not na(stopLine)
+        line.set_x2(stopLine, bar_index)
 
 // Индикатор выхода: возврат RSI к среднему
 exitSig = ta.crossover(rsi, 50)
@@ -159,8 +145,11 @@ if strategy.position_size > 0 and posProfitPerc >= beTrigger
     be = strategy.position_avg_price
     strategy.exit("BE", "Long1", stop = be)
     if na(stopLine)
-        stopLine := line.new(bar_index, be, bar_index, be,
-            extend=extend.right, color=color.red, width=2)
+        stopLine := line.new(entryBar, be, bar_index, be,
+            color=color.red, width=2)
+    else
+        line.set_y1(stopLine, be)
+        line.set_y2(stopLine, be)
 
 // === Лейблы с итоговой прибылью и длительностью сделки
 var int lastCloseBar = na
@@ -171,5 +160,25 @@ if showLabel and strategy.position_size == 0 and not na(entryBar) and (na(lastCl
          color = tradePnL >= 0 ? color.green : color.red,
          text = "P/L " + str.tostring(tradePnL, format.percent) + "\nBars " + str.tostring(durBars))
     lastCloseBar := bar_index
+
+// завершаем отрисовку линий при выходе из позиции
+if strategy.position_size == 0 and tradeActive
+    exitBar = bar_index
+    line.set_x2(entryLine, exitBar)
+    line.set_x2(tpLine, exitBar)
+    line.set_x2(layer2Line, exitBar)
+    line.set_x2(layer3Line, exitBar)
+    line.set_x2(layer4Line, exitBar)
+    if not na(stopLine)
+        line.set_x2(stopLine, exitBar)
+    tradeActive := false
+    entryLine := na
+    tpLine := na
+    stopLine := na
+    layer2Line := na
+    layer3Line := na
+    layer4Line := na
+    prvEntryPrice := na
+    entryBar := na
 
 // Рекомендации по адаптации под 1m/3m: увеличить maxBars для удержания (например, в 3-5 раз)


### PR DESCRIPTION
## Summary
- draw trade entry, exit, stop and averaging lines horizontally
- update lines each bar during the trade and finalize them at exit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837f568fbc8322b1284f8d297b2544