### PR TITLE
Improve line behavior and ADX filter

### DIFF
--- a/BTC_V3_Hybrid.pine
+++ b/BTC_V3_Hybrid.pine
@@ -10,6 +10,7 @@ maLen       = input.int(100, "MA Length")
 useMAFilter = input.bool(false, "Require price < MA for entry?")
 
 adxLen      = input.int(14,  "ADX Length")
+adxTF       = input.timeframe("240", "ADX TF")
 adxMax      = input.int(40,  "Макс. ADX для входа", tooltip = "Не входить, если ADX выше порога (сильный тренд)")
 useADX      = input.bool(true, "Включить фильтр ADX?")
 
@@ -46,7 +47,7 @@ showLabel = input.bool(true, "Show PnL/Dur?")
 // === Расчёт индикаторов
 rsi  = ta.rsi(close, rsiLen)
 ma   = ta.sma(close,  maLen)
-adx  = f_adx(adxLen)
+adx  = request.security(syminfo.tickerid, adxTF, f_adx(adxLen))
 atrP = ta.atr(atrLen) / close * 100  // ATR (%) от цены
 
 // === Фильтры
@@ -82,20 +83,23 @@ if strategy.position_size > 0 and strategy.opentrades == 1 and not tradeActive
     tradeActive := true
     // создаем линии для текущей сделки
     entryLine := line.new(bar_index, prvEntryPrice, bar_index, prvEntryPrice,
-         color=color.blue, width=2)
+         color=color.blue, width=2, xloc=xloc.bar_index, extend=extend.right)
     tpPrice = prvEntryPrice * (1 + deferTP / 100)
     tpLine := line.new(bar_index, tpPrice, bar_index, tpPrice,
-         color=color.green, width=2)
+         color=color.green, width=2, xloc=xloc.bar_index, extend=extend.right)
     // линии уровней усреднения
     layer2Line := line.new(bar_index, prvEntryPrice * (1 - layer2 / 100),
          bar_index, prvEntryPrice * (1 - layer2 / 100),
-         color=color.yellow, style=line.style_dotted)
+         color=color.yellow, style=line.style_dotted,
+         xloc=xloc.bar_index, extend=extend.right)
     layer3Line := line.new(bar_index, prvEntryPrice * (1 - layer3 / 100),
          bar_index, prvEntryPrice * (1 - layer3 / 100),
-         color=color.yellow, style=line.style_dotted)
+         color=color.yellow, style=line.style_dotted,
+         xloc=xloc.bar_index, extend=extend.right)
     layer4Line := line.new(bar_index, prvEntryPrice * (1 - layer4 / 100),
          bar_index, prvEntryPrice * (1 - layer4 / 100),
-         color=color.yellow, style=line.style_dotted)
+         color=color.yellow, style=line.style_dotted,
+         xloc=xloc.bar_index, extend=extend.right)
 
 // === Пирамидинг (усреднение при падении цены)
 if strategy.position_size > 0 and not na(prvEntryPrice)
@@ -115,13 +119,6 @@ if strategy.position_size > 0 and tradeActive
     curTP = strategy.position_avg_price * (1 + deferTP / 100)
     line.set_y1(tpLine, curTP)
     line.set_y2(tpLine, curTP)
-    line.set_x2(entryLine, bar_index)
-    line.set_x2(tpLine, bar_index)
-    line.set_x2(layer2Line, bar_index)
-    line.set_x2(layer3Line, bar_index)
-    line.set_x2(layer4Line, bar_index)
-    if not na(stopLine)
-        line.set_x2(stopLine, bar_index)
 
 // Индикатор выхода: возврат RSI к среднему
 exitSig = ta.crossover(rsi, 50)
@@ -146,7 +143,7 @@ if strategy.position_size > 0 and posProfitPerc >= beTrigger
     strategy.exit("BE", "Long1", stop = be)
     if na(stopLine)
         stopLine := line.new(entryBar, be, bar_index, be,
-             color=color.red, width=2)
+             color=color.red, width=2, xloc=xloc.bar_index, extend=extend.right)
     else
         line.set_y1(stopLine, be)
         line.set_y2(stopLine, be)
@@ -164,12 +161,18 @@ if showLabel and strategy.position_size == 0 and not na(entryBar) and (na(lastCl
 // завершаем отрисовку линий при выходе из позиции
 if strategy.position_size == 0 and tradeActive
     exitBar = bar_index
+    line.set_extend(entryLine, extend.none)
     line.set_x2(entryLine, exitBar)
+    line.set_extend(tpLine, extend.none)
     line.set_x2(tpLine, exitBar)
+    line.set_extend(layer2Line, extend.none)
     line.set_x2(layer2Line, exitBar)
+    line.set_extend(layer3Line, extend.none)
     line.set_x2(layer3Line, exitBar)
+    line.set_extend(layer4Line, extend.none)
     line.set_x2(layer4Line, exitBar)
     if not na(stopLine)
+        line.set_extend(stopLine, extend.none)
         line.set_x2(stopLine, exitBar)
     tradeActive := false
     entryLine := na


### PR DESCRIPTION
## Summary
- ensure trade lines stay anchored relative to bars using `extend.right`
- finalize drawn lines at exit with `line.set_extend(..., extend.none)`
- add an input for higher-timeframe ADX and compute it via `request.security`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883820ace508322be7279f1c398cf49