### PR TITLE
Fix line drawing after close

### DIFF
--- a/BTC_V3_Hybrid.pine
+++ b/BTC_V3_Hybrid.pine
@@ -63,6 +63,8 @@ canLong    = longSignal and maFilter and adxFilter and atrFilter
 var float prvEntryPrice = na
 var int   entryBar      = na
 var bool  tradeActive   = false
+var bool  exitInitiated = false
+var int   exitBarCmd    = na
 
 // линии отображения сделки
 var line entryLine  = na
@@ -81,6 +83,8 @@ if strategy.position_size > 0 and strategy.opentrades == 1 and not tradeActive
     prvEntryPrice := strategy.position_avg_price
     entryBar := bar_index
     tradeActive := true
+    exitInitiated := false
+    exitBarCmd := na
     // создаем линии для текущей сделки
     entryLine := line.new(bar_index, prvEntryPrice, bar_index, prvEntryPrice,
          color=color.blue, width=2, xloc=xloc.bar_index, extend=extend.right)
@@ -115,7 +119,7 @@ if strategy.position_size > 0 and not na(prvEntryPrice)
 posProfitPerc = strategy.position_size != 0 ? (close - strategy.position_avg_price) / strategy.position_avg_price * 100 : 0.0
 
 // обновляем линии во время открытой сделки
-if strategy.position_size > 0 and tradeActive
+if strategy.position_size > 0 and tradeActive and not exitInitiated
     curTP = strategy.position_avg_price * (1 + deferTP / 100)
     line.set_y1(tpLine, curTP)
     line.set_y2(tpLine, curTP)
@@ -127,6 +131,8 @@ exitSig = ta.crossover(rsi, 50)
 if strategy.position_size > 0 and exitSig
     if posProfitPerc >= minProfit
         strategy.close("Long1")
+        exitInitiated := true
+        exitBarCmd := bar_index
     else
         tpPrice = strategy.position_avg_price * (1 + deferTP / 100)
         strategy.exit("DeferredTP", "Long1", limit = tpPrice)
@@ -136,6 +142,8 @@ failSig = ta.crossunder(rsi, rsiLow)
 if strategy.position_size > 0
     if bar_index - entryBar > maxBars or failSig
         strategy.close("Long1")
+        exitInitiated := true
+        exitBarCmd := bar_index
 
 // === Перевод стопа в безубыток
 if strategy.position_size > 0 and posProfitPerc >= beTrigger
@@ -159,22 +167,26 @@ if showLabel and strategy.position_size == 0 and not na(entryBar) and (na(lastCl
     lastCloseBar := bar_index
 
 // завершаем отрисовку линий при выходе из позиции
-if strategy.position_size == 0 and tradeActive
-    exitBar = bar_index
+// фиксируем линии, когда даётся команда на закрытие сделки
+if tradeActive and exitInitiated
     line.set_extend(entryLine, extend.none)
-    line.set_x2(entryLine, exitBar)
+    line.set_x2(entryLine, exitBarCmd)
     line.set_extend(tpLine, extend.none)
-    line.set_x2(tpLine, exitBar)
+    line.set_x2(tpLine, exitBarCmd)
     line.set_extend(layer2Line, extend.none)
-    line.set_x2(layer2Line, exitBar)
+    line.set_x2(layer2Line, exitBarCmd)
     line.set_extend(layer3Line, extend.none)
-    line.set_x2(layer3Line, exitBar)
+    line.set_x2(layer3Line, exitBarCmd)
     line.set_extend(layer4Line, extend.none)
-    line.set_x2(layer4Line, exitBar)
+    line.set_x2(layer4Line, exitBarCmd)
     if not na(stopLine)
         line.set_extend(stopLine, extend.none)
-        line.set_x2(stopLine, exitBar)
+        line.set_x2(stopLine, exitBarCmd)
+
+// окончательно убираем линии после закрытия позиции
+if strategy.position_size == 0 and tradeActive
     tradeActive := false
+    exitInitiated := false
     entryLine := na
     tpLine := na
     stopLine := na


### PR DESCRIPTION
## Summary
- stop updating trade lines once close is commanded
- freeze line positions on exit command
- reset exit state on new entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68838532867c83228223ec5accde2bcc